### PR TITLE
Dependencies chapter update

### DIFF
--- a/manuscript/code-quality/05-dependencies.md
+++ b/manuscript/code-quality/05-dependencies.md
@@ -1,14 +1,14 @@
 # Dependency Management
 
-While writing projects, dependency management tends to be a common issue. Sometimes keeping up with the dependencies means you have to rewrite code. Bigger projects may provide **codemods** that can perform the required changes for you. They can also rely on deprecation patterns that tell you to rewrite certain pieces code before removing the functionality entirely.
+Keeping dependencies updated is important to have the latest bugfixes and security updates, but it needs a lot of work: once in a while you need to check which packages have new versions and how to migrate, sometimes you have to rewrite parts of your code. Bigger projects may provide [codemods](https://github.com/reactjs/react-codemod) that can perform the required changes for you. Or they can deprecate a feature with a warning message, giving you time to migrate before the feature is completely removed from the package.
 
 T> You should use **lockfiles** to manage the versions of your dependencies. Read the _Publishing Packages_ chapter to learn more about the approach.
 
 ## Keeping Dependencies Updated
 
-An important part of maintaining a project is keeping their dependencies updated. The hard part is to understand which updates won’t break your code and how to migrate to a new version otherwise. Ideally, dependencies have change logs with clear migration instructions and your project has a good test coverage as that will help in the process.
+The hard part of updating dependencies is to understand which updates won’t break your code and how to migrate to a new version otherwise. Ideally, dependencies have change logs with clear migration instructions and your project has a good test coverage.
 
-To understand which dependencies can be updated, run `npm outdated --depth=0`. You should get a result along this:
+To understand which dependencies can be updated, run `npm outdated`:
 
 ```bash
 Package                 Current  Wanted  Latest  Location
@@ -19,7 +19,7 @@ eslint-plugin-jsx-a11y    5.1.1   5.1.1   6.0.2  demo-project
 
 The _catalog_ case is the curious one. The project has set it as a development dependency using a version range `"catalog": "^3.0.0",`. According to the output, the project has version 3.0.0 installed while the latest available version is 3.1.2.
 
-Running [npm update](https://docs.npmjs.com/cli/update) would update it to that version but there are no guarantees the new version will work given SemVer is only a verbal contract. A package can still break functionality and you should not update package versions blindly!
+Running [npm update](https://docs.npmjs.com/cli/update) would update it to that version but there are no guarantees the new version will work.
 
 The other dependencies would require either a manual change to _package.json_ or using a specific tool such as one listed below:
 
@@ -30,7 +30,21 @@ The other dependencies would require either a manual change to _package.json_ or
 * [Renovate](https://www.npmjs.com/package/renovate) is an open source alternative to Greenkeeper. [Read Renovate interview](https://survivejs.com/blog/renovate-interview/) to learn more about the tool.
 * [David](https://david-dm.org/) gives you a _README_ badge that will show status of your dependencies.
 
-T> `npm ls` and `npm ls <package name>` allow you to figure out which versions you have installed. `npm ls -g` performs a similar lookup against the globally installed packages.
+T> `npm ls` and `npm ls <package name>` allow you to figure out which versions you have installed. `npm ls -g` shows versions of globally installed packages.
+
+## Understanding Version Ranges
+
+Usually version consists of three numbers separated by a dot: `MAJOR.MINOR.PATCH`. Prerelease versions (alpha/beta/rc) may look like 1.2.3-alpha.1 or 1.2.4-beta.1.
+
+Many npm packages follow [SemVer](https://semver.org/), which means that only major version change (like 3.0.0 to 4.0.0) may contain breaking changes, but some projects follow different conventions or no convention at all. Many projects treat 0.x versions as major, so they may have breaking changes, since the project is in active development. Alpha and beta releases may contain breaking changes too. In any case even a patch release may contain a breaking change because of a new bug or a bugfix. You should always carefully read the change log before any upgrade.
+
+Depending on a project you may want to specify [version ranges](https://docs.npmjs.com/misc/semver) differently in _package.json_:
+
+* Caret (`^1.2.3`, npm default) — good for most projects, will catch all updates inside a major version (1.9.3 but not 2.0.0).
+* Tilda (`~1.2.3`) — projects that may have breaking changes in minor releases, will catch all updates inside a minor version (1.2.17 but not 1.3.0).
+* Exact version (`1.2.3`) — the most strict, only manual updates.
+
+T> Check out the [npm semver calculator](https://semver.npmjs.com/) to better understand how version ranges work.
 
 ## Conclusion
 


### PR DESCRIPTION
* New section *Understanding Version Ranges*
* Remove `--depth=0` from `npm outdated` — it’s a default value
* Small tweaks