### PR TITLE
Use ".eslintrc.json" because ".eslintrc" is deprecated

### DIFF
--- a/manuscript/appendices/02-customizing-eslint.md
+++ b/manuscript/appendices/02-customizing-eslint.md
@@ -60,18 +60,18 @@ ESLint provides two ways to deal with this: local and global. To set it per file
 
 Global configuration is possible as well. In this case, you can use `env` key:
 
-**.eslintrc.js**
+**.eslintrc.json**
 
-```javascript
-module.exports = {
-  env: {
-    browser: true,
-    commonjs: true,
-    es6: true,
-    node: true,
+```json
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "node": true,
   },
   // ...
-};
+}
 ```
 
 <!-- textlint-enable -->
@@ -133,35 +133,35 @@ Next, you need to execute `npm link` within `eslint-plugin-custom` to make your 
 
 You need to alter the project configuration to make it find the plugin and the rule within.
 
-**.eslintrc.js**
+**.eslintrc.json**
 
 <!-- textlint-disable -->
 
 <!-- skip-example -->
 
-```javascript
-module.exports = {
-  ...
-  plugins: [
-    ...
+```json
+{
+  // ...
+  "plugins": [
+    // ...
 leanpub-start-insert
-    'custom'
+    "custom"
 leanpub-end-insert
   ],
-  rules: {
-    ...
+  "rules": {
+    // ...
 leanpub-start-insert
-    'custom/demo': 1,
+    "custom/demo": 1,
 leanpub-end-insert
   }
-};
+}
 ```
 
 <!-- textlint-enable -->
 
 If you invoke ESLint now, you should see a bunch of warnings. Of course, the rule doesn’t do anything impressive yet. To move forward, check out the [official plugin documentation](http://eslint.org/docs/developer-guide/working-with-plugins.html) and [rules](http://eslint.org/docs/developer-guide/working-with-rules.html).
 
-You can also check out the existing rules and plugins for inspiration to see how they achieve certain things. ESLint allows you to [extend these rulesets](http://eslint.org/docs/user-guide/configuring.html#extending-configuration-files) through `extends` property. It accepts either a path to it (`"extends": "./node_modules/coding-standard/.eslintrc"`) or an array of paths. The entries are applied in the given order, and later ones override the former.
+You can also check out the existing rules and plugins for inspiration to see how they achieve certain things. ESLint allows you to [extend these rulesets](http://eslint.org/docs/user-guide/configuring.html#extending-configuration-files) through `extends` property. It accepts either a path to it (`"extends": "./node_modules/coding-standard/.eslintrc.json"`) or an array of paths. The entries are applied in the given order, and later ones override the former.
 
 ## ESLint Resources
 

--- a/manuscript/code-quality/01-linting.md
+++ b/manuscript/code-quality/01-linting.md
@@ -67,7 +67,7 @@ Add a new script to your _package.json_.
 
 The `--fix` flag tells ESLint to fix problems automatically [if it can](https://eslint.org/docs/rules/).
 
-Create a config file, _.eslintrc_:
+Create a config file, _.eslintrc.json_:
 
 ```json
 {
@@ -83,9 +83,9 @@ And finally run:
 npm run lint:js
 ```
 
-You may need to tweak your _.eslintrc_ according to your project needs:
+You may need to tweak your ESLint config according to your project needs:
 
-**.eslintrc**
+**.eslintrc.json**
 
 ```json
 {
@@ -129,9 +129,9 @@ T> [Use Mrm](https://github.com/sapegin/mrm-tasks/tree/master/packages/mrm-task-
 
 ### ESLint Configuration Formats
 
-_.eslintrc_ supports [JSON5](http://json5.org/) format by default. It’s a proposed extension to JSON that enables features like comments and trailing commas.
+_.eslintrc.json_ supports JavaScript-style comments.
 
-ESLint supports other formats of config files, such as YAML or JavaScript. JSON5 is a good choice, because other tools can modify such files.
+ESLint supports other formats of config files, such as YAML or JavaScript. JSON is a good choice, because other tools can modify such files.
 
 ## Linting TypeScript With TSLint
 

--- a/manuscript/code-quality/02-code-formatting.md
+++ b/manuscript/code-quality/02-code-formatting.md
@@ -157,9 +157,9 @@ npm install prettier eslint-plugin-prettier --save-dev
 
 {pagebreak}
 
-Update your _.eslintrc_ like this:
+Update your ESLint config like this:
 
-**.eslintrc**
+**.eslintrc.json**
 
 ```json
 {

--- a/manuscript/packaging/02-anatomy.md
+++ b/manuscript/packaging/02-anatomy.md
@@ -249,7 +249,7 @@ Same with the source code if you compile it before publishing. These files aren�
 
 In larger projects, you often find the following files that should be excluded from an npm distribution:
 
-* Tooling configuration, like _.babelrc_, _.eslintrc_, _.travis.yml_ or _webpack.config.js_ — files like _.babelrc_ may easily break your user’s build if they try to compile _node_modules_ folder and don’t have one of the plugins listed in your config.
+* Tooling configuration, like _.babelrc_, _.eslintrc.json_, _.travis.yml_ or _webpack.config.js_ — files like _.babelrc_ may easily break your user’s build if they try to compile _node_modules_ folder and don’t have one of the plugins listed in your config.
 * Tooling or build artifacts like log files — usually anything you have in _.gitignore_ which npm will use by default unless you have _.npmignore_ file. In the latter case you’ll need to copy these patterns from _.gitignore_.
 * File that are required only for development: build scripts or _CONTRIBUTING.md_.
 * Any big files, like images.


### PR DESCRIPTION
Fixes #88